### PR TITLE
Add request timeout when uploading files

### DIFF
--- a/uploader.py
+++ b/uploader.py
@@ -37,6 +37,7 @@ while True:
                         URL,
                         headers=headers,
                         files={"document": (pdf.name, fp, "application/pdf")},
+                        timeout=30,
                     )
                 r.raise_for_status()
                 cur.execute("INSERT INTO done VALUES(?,?,?)",


### PR DESCRIPTION
## Summary
- ensure the upload request fails quickly if the server is unresponsive

## Testing
- `python -m py_compile uploader.py`

------
https://chatgpt.com/codex/tasks/task_e_6876bb5ebbcc83249ce77b4f80dd7319