### PR TITLE
Add SHA-256 tracking for uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Helper container to upload PDFs to Paperless-NGX using its REST API.
 | `PAPERLESS_URL` | Base URL of your Paperless-NGX instance, e.g. `http://paperless.lan:8000` |
 | `PAPERLESS_TOKEN` | API token created in Paperless. Required. |
 | `SOURCE_DIRS` | Semicolon separated list of directories to scan for `*.pdf`. |
-| `STATE_DB` | Path to the SQLite database that tracks uploaded files. |
+| `STATE_DB` | Path to the SQLite database that tracks uploaded files and their hashes. |
 | `MIN_AGE` | Seconds to wait after file modification time before upload (default `60`). |
 | `SCAN_INTERVAL` | Seconds between directory scans (default `300`). |
 | `TZ` | Optional timezone for logs. |
@@ -40,6 +40,9 @@ docker run \
 [OK] /nas/p21sftp/PO_456.pdf
 ```
 Each file is uploaded once; later scans skip it silently.
+The uploader also stores a SHA-256 hash for each document in the state
+database so that modified files are re-uploaded even if their size and
+timestamp are unchanged.
 
 ## Adding metadata fields
 

--- a/uploader.py
+++ b/uploader.py
@@ -1,4 +1,4 @@
-import os, time, pathlib, sqlite3, requests, sys
+import os, time, pathlib, sqlite3, requests, sys, hashlib
 
 url_env   = os.getenv("PAPERLESS_URL")
 token_env = os.getenv("PAPERLESS_TOKEN")
@@ -15,9 +15,24 @@ DB    = os.getenv("STATE_DB", "/state/uploaded.db")
 DIRS  = os.getenv("SOURCE_DIRS", "").split(";")
 
 con = sqlite3.connect(DB)
-con.execute("CREATE TABLE IF NOT EXISTS done(path TEXT PRIMARY KEY, m REAL, s INTEGER)")
+con.execute(
+    "CREATE TABLE IF NOT EXISTS done(path TEXT PRIMARY KEY, m REAL, s INTEGER, h TEXT)"
+)
+
+# Add hash column if database was created by an older version
+cols = [row[1] for row in con.execute("PRAGMA table_info(done)")] 
+if "h" not in cols:
+    con.execute("ALTER TABLE done ADD COLUMN h TEXT")
 
 headers = {"Authorization": f"Token {TOKEN}"}
+
+def file_sha256(path):
+    h = hashlib.sha256()
+    with path.open("rb") as fp:
+        for chunk in iter(lambda: fp.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
 
 while True:
     cur = con.cursor()
@@ -26,8 +41,12 @@ while True:
             st = pdf.stat()
             if time.time() - st.st_mtime < MIN:
                 continue                                # file still being written
-            cur.execute("SELECT 1 FROM done WHERE path=? AND m=? AND s=?",
-                        (str(pdf), st.st_mtime, st.st_size))
+
+            sha = file_sha256(pdf)
+            cur.execute(
+                "SELECT 1 FROM done WHERE path=? AND m=? AND s=? AND h=?",
+                (str(pdf), st.st_mtime, st.st_size, sha),
+            )
             if cur.fetchone():
                 continue                                # already uploaded
 
@@ -40,8 +59,10 @@ while True:
                         timeout=30,
                     )
                 r.raise_for_status()
-                cur.execute("INSERT INTO done VALUES(?,?,?)",
-                            (str(pdf), st.st_mtime, st.st_size))
+                cur.execute(
+                    "INSERT OR REPLACE INTO done VALUES(?,?,?,?)",
+                    (str(pdf), st.st_mtime, st.st_size, sha),
+                )
                 con.commit()
                 print(f"[OK] {pdf}")
             except Exception as e:


### PR DESCRIPTION
## Summary
- store a SHA-256 digest for each document in the SQLite state DB
- re-check this hash to avoid skipping modified files
- mention the hash tracking in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile uploader.py`


------
https://chatgpt.com/codex/tasks/task_e_6876c9483888832484bcf2595f9b5c60